### PR TITLE
タグ周りの不具合の解決

### DIFF
--- a/components/SummaryCard.vue
+++ b/components/SummaryCard.vue
@@ -3,7 +3,7 @@
     <b-media>
       <h5 class="mt-0"><nuxt-link :to="`/summaries/${summary.id}`">{{ summary.title }}</nuxt-link></h5>
       <div>by: {{ summary.resumer }}</div>
-      <nuxt-link :to="`/summaries/tag/${tag}`" class="tag tag-primary" v-for="(tag, idx) in summary.tags" :key="idx">
+      <nuxt-link :to="`/summaries/tag/${tag.toLowerCase()}`" class="tag tag-primary" v-for="(tag, idx) in summary.tags" :key="idx">
         {{ tag }}
       </nuxt-link>
     </b-media>

--- a/modules/fetchData.js
+++ b/modules/fetchData.js
@@ -85,13 +85,13 @@ module.exports = function fetchData() {
 
         // Create summary per tag
         fs.emptyDir('static/data/summaries/tag/');
-        const tagset = new Set(allSummaries.data.reduce((a, b) => [...a, ...b.tags], []));
+        const tagset = new Set(allSummaries.data.reduce((a, b) => [...a, ...b.tags], []).map(tag => tag.toLowerCase()));
 
         fetcher.push(writeData('static/data/summaries/tags.json', { content: Array.from(tagset) }));
 
         console.log(tagset)
         for (let tag of tagset) {
-          let summariesByTag = allSummaries.data.filter(summary => summary.tags.includes(tag));
+          let summariesByTag = allSummaries.data.filter(summary => summary.tags.map(tag => tag.toLowerCase()).includes(tag));
           let tagDataPath = `static/data/summaries/tag/${tag}/list.json`;
 
           fetcher.push(writeData(tagDataPath, { content: summariesByTag, meta: { totalCount: summariesByTag.length } }));

--- a/modules/fetchData.js
+++ b/modules/fetchData.js
@@ -30,7 +30,7 @@ module.exports = function fetchData() {
       return new Promise((resolve, reject) => {
         try {
           fs.ensureFileSync(path)
-          fs.writeFile(path, new Buffer(base64encodedData, 'base64'), resolve(`${path} Write Successful`));
+          fs.writeFile(path, Buffer.from(base64encodedData, 'base64'), resolve(`${path} Write Successful`));
         } catch(e) {
           console.error(`${path} Write failed. ${e}`)
                 reject(`${path} Write Failed. ${e}`)

--- a/pages/summaries/_id.vue
+++ b/pages/summaries/_id.vue
@@ -62,7 +62,7 @@
         <div class="article-footer">
           <ul class="article-tag-list">
             <li v-for="(tag, idx) in summary.tags" :key="idx" class="article-tag-list-item">
-              <nuxt-link :to="`/summaries/tag/${tag}`" class="article-tag-list-link">
+              <nuxt-link :to="`/summaries/tag/${tag.toLowerCase()}`" class="article-tag-list-link">
                 {{ tag }}
               </nuxt-link>
             </li>

--- a/pages/summaries/tag/_tag.vue
+++ b/pages/summaries/tag/_tag.vue
@@ -50,7 +50,7 @@ export default {
   },
   asyncData({ params }) {
     let tag = params.tag;
-    let { content: summaries, meta: { totalCount } } = require(`~/static/data/summaries/tag/${tag}/list.json`);
+    let { content: summaries, meta: { totalCount } } = require(`~/static/data/summaries/tag/${tag.toLowerCase()}/list.json`);
     return {
       summaries,
       tag,


### PR DESCRIPTION
タグの大文字小文字を統一せずそのままファイル名にしてタグファイルが作られていたが，
ファイルアクセスの時にはcase insensitivityが働いて無いファイルを探そうとしたため，
ファイル回りのタグ名を小文字に統一．