### PR TITLE
add updating apt for deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             - "c6:93:10:09:99:7f:e3:cf:9e:77:b6:7a:0c:13:b6:f5"
       - run:
           name: install-sshpass
-          command: 'sudo apt-get install sshpass'
+          command: 'sudo apt-get update && sudo apt-get install sshpass'
       - attach_workspace:
           at: ./dist
       - run:


### PR DESCRIPTION
下記エラーの回避：
```
$ #!/bin/bash -eo pipefail
sudo apt-get install sshpass
Reading package lists... Done


Building dependency tree       


Reading state information... Done

E: Unable to locate package sshpass
Exited with code 100
```